### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/tarka/dns-edit/compare/v0.1.1...v0.2.0) - 2025-09-23
+
+### Other
+
+- Simplify address parameters.
+- Use runtime-agnostic Mutex crate
+- Consistent naming.
+- Remove some old code.
+- Add delete to gandi impl and duplicate tests from dnsimple module.
+- Add record update
+- Remove on-off cleanup code.
+- Add delete operation and use it for cleanup.
+- Expand API some more.
+- Add get_v4_record() impl.
+- Serde supports Ipv4Addr.
+- We don't need Arc around the mutex ATM.
+- Use Mutex rather than OnceLock for simplicity.
+- Add ability to optionally fetch account id from upstream.
+- Minor type updates.
+- Rough start to dnsimple support
+- Remove old code.
+- Minor cleanups.
+- Api tweak.
+- Update Gandi impl to new http api.
+- Dedup error handling.
+- Simplify functions and remove some duplication.
+- Debian doesn't have as many agents?
+- Fix matrix config.
+- Start of Github CI.
+- Don't decode error body, just add it to the error message.
+- Add dir-locals.el.
+- Minor formatting.
+- Use test domain from env.
+- Add status badges.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dns-edit"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-lock",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns-edit"
-version = "0.1.1"
+version = "0.2.0"
 description = "A minimal library of DNS provider utilities"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/tarka/dns-edit"


### PR DESCRIPTION



## 🤖 New release

* `dns-edit`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `dns-edit` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.44.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:ApiError in /tmp/.tmp5Hwufr/dns-edit/src/errors.rs:9
  variant Error:UrlError in /tmp/.tmp5Hwufr/dns-edit/src/errors.rs:18

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.44.0/src/lints/trait_method_added.ron

Failed in:
  trait method dns_edit::DnsProvider::create_v4_record in file /tmp/.tmp5Hwufr/dns-edit/src/lib.rs:46
  trait method dns_edit::DnsProvider::update_v4_record in file /tmp/.tmp5Hwufr/dns-edit/src/lib.rs:47
  trait method dns_edit::DnsProvider::delete_v4_record in file /tmp/.tmp5Hwufr/dns-edit/src/lib.rs:48

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.44.0/src/lints/trait_method_missing.ron

Failed in:
  method set_v4_record of trait DnsProvider, previously in file /tmp/.tmpl3y7y9/dns-edit/src/lib.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/tarka/dns-edit/compare/v0.1.1...v0.2.0) - 2025-09-23

### Other

- Simplify address parameters.
- Use runtime-agnostic Mutex crate
- Consistent naming.
- Remove some old code.
- Add delete to gandi impl and duplicate tests from dnsimple module.
- Add record update
- Remove on-off cleanup code.
- Add delete operation and use it for cleanup.
- Expand API some more.
- Add get_v4_record() impl.
- Serde supports Ipv4Addr.
- We don't need Arc around the mutex ATM.
- Use Mutex rather than OnceLock for simplicity.
- Add ability to optionally fetch account id from upstream.
- Minor type updates.
- Rough start to dnsimple support
- Remove old code.
- Minor cleanups.
- Api tweak.
- Update Gandi impl to new http api.
- Dedup error handling.
- Simplify functions and remove some duplication.
- Debian doesn't have as many agents?
- Fix matrix config.
- Start of Github CI.
- Don't decode error body, just add it to the error message.
- Add dir-locals.el.
- Minor formatting.
- Use test domain from env.
- Add status badges.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).