### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/tarka/dns-edit/compare/v0.2.0...v0.2.1) - 2025-09-23
+
+### Other
+
+- Add feature flags for providers.
+- Bump dependencies.
+
 ## [0.2.0](https://github.com/tarka/dns-edit/compare/v0.1.1...v0.2.0) - 2025-09-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dns-edit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-lock",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns-edit"
-version = "0.2.0"
+version = "0.2.1"
 description = "A minimal library of DNS provider utilities"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/tarka/dns-edit"


### PR DESCRIPTION



## 🤖 New release

* `dns-edit`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/tarka/dns-edit/compare/v0.2.0...v0.2.1) - 2025-09-23

### Other

- Add feature flags for providers.
- Bump dependencies.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).