### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/tarka/zone-edit/compare/v0.2.1...v0.2.2) - 2025-09-24
+
+### Other
+
+- Change README to point to renamed project.
+- spawn() shouldn't be pub
+
 ## [0.2.1](https://github.com/tarka/dns-edit/compare/v0.2.0...v0.2.1) - 2025-09-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dns-edit"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-lock",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns-edit"
-version = "0.2.1"
+version = "0.2.2"
 description = "A minimal library of DNS provider utilities"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/tarka/dns-edit"


### PR DESCRIPTION



## 🤖 New release

* `dns-edit`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/tarka/zone-edit/compare/v0.2.1...v0.2.2) - 2025-09-24

### Other

- Change README to point to renamed project.
- spawn() shouldn't be pub
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).