### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/tarka/zone-edit/compare/v0.2.2...v0.2.3) - 2025-09-24
+
+### Other
+
+- Cleanup Cargo.toml.
+
 ## [0.2.2](https://github.com/tarka/zone-edit/compare/v0.2.1...v0.2.2) - 2025-09-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,7 +1726,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zone-edit"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-lock",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zone-edit"
-version = "0.2.2"
+version = "0.2.3"
 description = "A minimal library of DNS provider utilities"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/tarka/zone-edit"


### PR DESCRIPTION



## 🤖 New release

* `zone-edit`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/tarka/zone-edit/compare/v0.2.2...v0.2.3) - 2025-09-24

### Other

- Cleanup Cargo.toml.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).