### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/tarka/zone-edit/compare/v0.2.3...v0.3.0) - 2025-09-26
+
+### Other
+
+- Add helper functions for common operations.
+- Fix gandi record type.
+- Add support and testing for TXT types.
+- Move API entirely to generics
+- Start moving to multiple record types
+- Use async OnceCell/Arc for root store to save regenerating it.
+- Add a note about using pollster+thread for fallback.
+- Minor import cleanups.
+- Fix base URL.
+- Fix CI badge.
+
 ## [0.2.3](https://github.com/tarka/zone-edit/compare/v0.2.2...v0.2.3) - 2025-09-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,7 +1726,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zone-edit"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "async-lock",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zone-edit"
-version = "0.2.3"
+version = "0.3.0"
 description = "A minimal library of DNS provider utilities"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/tarka/zone-edit"


### PR DESCRIPTION



## 🤖 New release

* `zone-edit`: 0.2.3 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `zone-edit` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.44.0/src/lints/trait_method_added.ron

Failed in:
  trait method zone_edit::DnsProvider::get_record in file /tmp/.tmp9SsxHE/zone-edit/src/lib.rs:48
  trait method zone_edit::DnsProvider::create_record in file /tmp/.tmp9SsxHE/zone-edit/src/lib.rs:52
  trait method zone_edit::DnsProvider::update_record in file /tmp/.tmp9SsxHE/zone-edit/src/lib.rs:56
  trait method zone_edit::DnsProvider::delete_record in file /tmp/.tmp9SsxHE/zone-edit/src/lib.rs:60

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.44.0/src/lints/trait_method_missing.ron

Failed in:
  method get_v4_record of trait DnsProvider, previously in file /tmp/.tmpQzOrgF/zone-edit/src/lib.rs:48
  method create_v4_record of trait DnsProvider, previously in file /tmp/.tmpQzOrgF/zone-edit/src/lib.rs:49
  method update_v4_record of trait DnsProvider, previously in file /tmp/.tmpQzOrgF/zone-edit/src/lib.rs:50
  method delete_v4_record of trait DnsProvider, previously in file /tmp/.tmpQzOrgF/zone-edit/src/lib.rs:51
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/tarka/zone-edit/compare/v0.2.3...v0.3.0) - 2025-09-26

### Other

- Add helper functions for common operations.
- Fix gandi record type.
- Add support and testing for TXT types.
- Move API entirely to generics
- Start moving to multiple record types
- Use async OnceCell/Arc for root store to save regenerating it.
- Add a note about using pollster+thread for fallback.
- Minor import cleanups.
- Fix base URL.
- Fix CI badge.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).