### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tarka/zone-edit/compare/v0.3.0...v0.3.1) - 2025-09-26
+
+### Other
+
+- Add helpers for A records
+
 ## [0.3.0](https://github.com/tarka/zone-edit/compare/v0.2.3...v0.3.0) - 2025-09-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,7 +1726,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zone-edit"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-lock",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zone-edit"
-version = "0.3.0"
+version = "0.3.1"
 description = "A minimal library of DNS provider utilities"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/tarka/zone-edit"


### PR DESCRIPTION



## 🤖 New release

* `zone-edit`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/tarka/zone-edit/compare/v0.3.0...v0.3.1) - 2025-09-26

### Other

- Add helpers for A records
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).