### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/tarka/zone-edit/compare/v0.4.2...v0.4.3) - 2025-10-25
+
+### Other
+
+- Update readme with rename.
+
 ## [0.4.2](https://github.com/tarka/zone-edit/compare/v0.4.1...v0.4.2) - 2025-10-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "zone-edit"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "acme-micro",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zone-edit"
-version = "0.4.2"
+version = "0.4.3"
 description = "A minimal library of DNS provider utilities"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/tarka/zone-edit"


### PR DESCRIPTION



## 🤖 New release

* `zone-edit`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/tarka/zone-edit/compare/v0.4.2...v0.4.3) - 2025-10-25

### Other

- Update readme with rename.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).